### PR TITLE
Fix logical error in text.tact #603

### DIFF
--- a/stdlib/std/text.tact
+++ b/stdlib/std/text.tact
@@ -71,9 +71,9 @@ extends fun fromBase64(self: Slice): Slice {
             result = result.storeUint(code - (97 - 26), 6);
         } else if (code >= 48 && code <= 57) { // 0-9
             result = result.storeUint(code + (52 - 48), 6);
-        } else if (code == 45 || code == 43) { // - or +
+        } else if (code == 45 && code == 43) { // - or +
             result = result.storeUint(62, 6);
-        } else if (code == 95 || code == 47) { // _ or /
+        } else if (code == 95 && code == 47) { // _ or /
             result = result.storeUint(63, 6);
         } else if (code == 61) { // =
             // Skip


### PR DESCRIPTION
The fromBase64 function contains a logical error in the if conditions used to check for specific characters. Instead of using the logical AND operator &&, the code uses the "||" to combine conditions. This will result in a syntax error. 

Original:
  } else if (code == 45 || code == 43) { // - or +
            result = result.storeUint(62, 6);
        } else if (code == 95 || code == 47) { // _ or /

Improved:
  } else if (code == 45 && code == 43) { // - or +
            result = result.storeUint(62, 6);
        } else if (code == 95 && code == 47) { // _ or /

Closes #603

- [x] I have updated CHANGELOG.md
- [x] I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pull/PR-NUMBER
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings

TON Wallet: UQCi49NtqN9j0k8xciv0TzX8MR2NC6I7G1ABdzVMdLrpRG1s